### PR TITLE
Fix documentation for AppendError

### DIFF
--- a/docs/content/en/docs/Developer Guide/handling-failures.md
+++ b/docs/content/en/docs/Developer Guide/handling-failures.md
@@ -73,5 +73,5 @@ filters.Log4jGrokFilter.withOnFailure=AppendError
 
 filters.AppendError.type=io.streamthoughts.kafka.connect.filepulse.filter.AppendFilter
 filters.AppendError.field=$.exceptionMessage
-filters.AppendError.value={{ $error.message }}
+filters.AppendError.value={{ $error.exceptionMessage }}
 ```


### PR DESCRIPTION
The exemple in the documentation of Handling Error => $error.message raise en error.

$error.exceptionMessage seems to be the correct configuration in version 2.6.0